### PR TITLE
Fixed broken SynapseUtils import

### DIFF
--- a/src/corvus_python/synapse/__init__.py
+++ b/src/corvus_python/synapse/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
 from .sync_tables_locally import sync_synapse_tables_to_local_spark, ObjectSyncDetails
-from .synapse_utils import SynapseUtils
+from .synapse_utils import SynapseUtilities

--- a/src/corvus_python/synapse/synapse_utils.py
+++ b/src/corvus_python/synapse/synapse_utils.py
@@ -3,7 +3,7 @@ import urllib.parse
 from datetime import datetime, timedelta
 import time
 
-from corvus_python.pyspark.utilities.spark_utils.spark_utils import get_spark_utils
+from corvus_python.pyspark.utilities import get_spark_utils
 
 
 class SynapsePipelineError(Exception):


### PR DESCRIPTION
Fixed broken SynapseUtils import. I think the class was renamed to `SynapseUtilities` but wasn't changed in the `__init__.py` file. This caused errors when importing dependent modules.